### PR TITLE
feat(upgrade-sdk): Upgrade to sdk `0.2.0`

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -12,26 +12,35 @@ static string ReverseString(byte[] data)
     return new string(charArray);
 }
 
+// configure logging
+RainwayRuntime.SetLogLevel(RainwayLogLevel.Info, null);
+RainwayRuntime.SetLogSink((level, target, message) =>
+{
+    Console.WriteLine($"{level} [{target}] {message}");
+});
+
 // the runtime configuration
 var config = new RainwayConfig
 {
     // your publishable API key should go here
-    ApiKey = string.Empty,
+    ApiKey = "YOUR_API_KEY",
+    // any string identifying a user or entity within your app (optional)
     ExternalId = string.Empty,
-    LogSink = (level, message) => Console.WriteLine($"[RW][{level.ToString().ToUpper()}] {message}"),
     // audo accepts all connection request
     OnConnectionRequest = (request) => request.Accept(),
     // auto accepts all stream request and gives full input privileges to the remote peer 
-    OnStreamRequest = (requests) => requests.Accept(new RainwayPeerPermissions(true, true, true)),
+    OnStreamRequest = (requests) => requests.Accept(new RainwayStreamConfig() {
+        InputLevel = RainwayInputLevel.Mouse | RainwayInputLevel.Keyboard | RainwayInputLevel.GamepadPortAll,
+        IsolateProcessIds = Array.Empty<uint>()
+    }),
     // reverses the data sent by a peer and echos it back
     OnPeerMessage = (peer, data) => peer.Send(ReverseString(data))
 };
 
 // initalize the runtime
 using var runtime = await RainwayRuntime.Initialize(config);
-runtime.SetLogLevel(RainwayLogLevel.Information);
 Console.WriteLine($"Rainway SDK Version: {runtime.Version}");
-Console.WriteLine($"Hostname: {runtime.Hostname}");
+Console.WriteLine($"Peer Id: {runtime.PeerId}");
 Console.WriteLine("Press Ctrl+C To Terminate");
 
 var closeEvent = new AutoResetEvent(false);

--- a/rainway-sdk-demo.csproj
+++ b/rainway-sdk-demo.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="rainway-sdk" Version="0.1.4" />
+    <PackageReference Include="rainway-sdk" Version="0.2.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
BREAKING CHANGE: rainway-sdk `0.2.0` API changed. Fixes #3.

Makes the small changes needed to use rainway-sdk `0.2.0`  including bumping the nuget version itself.