### PR TITLE
feat(upgrade): Upgrade to `0.2.1` sdk build

### DIFF
--- a/rainway-sdk-demo.csproj
+++ b/rainway-sdk-demo.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="rainway-sdk" Version="0.2.0" />
+    <PackageReference Include="rainway-sdk" Version="0.2.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This build fixes an issue with enhanced pointer precision failing to be disabled when a stream starts. This is a backward compatible fix.